### PR TITLE
Use a function returning now instead block.timestamp so time fastforward can be tested

### DIFF
--- a/contracts/liquidator/FantomLiquidationManager.sol
+++ b/contracts/liquidator/FantomLiquidationManager.sol
@@ -196,7 +196,7 @@ contract FantomLiquidationManager is Initializable, Ownable, FantomMintErrorCode
     ) {
         require(auctionIndexer[_nonce] > 0, "Auction not found");
         AuctionInformation storage _auction = auctionList[auctionIndexer[_nonce] - 1];
-        uint timeDiff = block.timestamp.sub(_auction.startTime);
+        uint timeDiff = _now().sub(_auction.startTime);
         uint currentRound = timeDiff.div(_auction.intervalTime);
         uint offeringRatio = _auction.startPrice.add(currentRound.mul(_auction.intervalPrice));
 
@@ -223,18 +223,18 @@ contract FantomLiquidationManager is Initializable, Ownable, FantomMintErrorCode
         require(auctionIndexer[_nonce] > 0, "Auction not found");
         AuctionInformation storage _auction = auctionList[auctionIndexer[_nonce] - 1];
         require(_auction.round > 0, "Auction not found");
-        uint timeDiff = block.timestamp.sub(_auction.startTime);
+        uint timeDiff = _now().sub(_auction.startTime);
         uint currentRound = timeDiff.div(_auction.intervalTime);
         uint _nextPrice = _auction.startPrice.add(currentRound.mul(_auction.intervalPrice));
-        if (_auction.endTime >= block.timestamp || _nextPrice >= _auction.minPrice) {
+        if (_auction.endTime >= _now() || _nextPrice >= _auction.minPrice) {
             // Restart the Auction
             _auction.round = _auction.round + 1;
             _auction.startPrice = auctionBeginPrice;
             _auction.intervalPrice = intervalPriceDiff;
             _auction.minPrice = defaultMinPrice;
-            _auction.startTime = block.timestamp;
+            _auction.startTime = _now();
             _auction.intervalTime = intervalTimeDiff;
-            _auction.endTime = block.timestamp.add(auctionDuration);
+            _auction.endTime = _now().add(auctionDuration);
             emit AuctionRestarted(_nonce, _auction.owner);
         }
     }
@@ -259,7 +259,7 @@ contract FantomLiquidationManager is Initializable, Ownable, FantomMintErrorCode
         require(_auction.round > 0, "Auction not found");
         require(percentPrecision >= _percentage, "Collateral is not sufficient to buy.");
 
-        uint timeDiff = block.timestamp.sub(_auction.startTime);
+        uint timeDiff = _now().sub(_auction.startTime);
         uint currentRound = timeDiff.div(_auction.intervalTime);
         uint offeringRatio = _auction.startPrice.add(currentRound.mul(_auction.intervalPrice));
 
@@ -322,9 +322,9 @@ contract FantomLiquidationManager is Initializable, Ownable, FantomMintErrorCode
         _tempAuction.startPrice = auctionBeginPrice;
         _tempAuction.intervalPrice = intervalPriceDiff;
         _tempAuction.minPrice = defaultMinPrice;
-        _tempAuction.startTime = block.timestamp;
+        _tempAuction.startTime = _now();
         _tempAuction.intervalTime = intervalTimeDiff;
-        _tempAuction.endTime = block.timestamp + auctionDuration;
+        _tempAuction.endTime = _now() + auctionDuration;
 
         auctionList.push(_tempAuction);
 
@@ -367,4 +367,9 @@ contract FantomLiquidationManager is Initializable, Ownable, FantomMintErrorCode
     function updateLiquidationFlag(bool _live) external auth {
         live = _live;
     }
+
+    function _now() internal view returns (uint256) {
+        return now;
+    }
+
 }

--- a/contracts/mocks/MockFantomLiquidationManager.sol
+++ b/contracts/mocks/MockFantomLiquidationManager.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.5.0;
+
+import "../liquidator/FantomLiquidationManager.sol";
+
+contract MockFantomLiquidationManager is FantomLiquidationManager {
+
+    uint256 public time;
+    function setTime(uint256 t) public {
+        time = t;
+    }
+
+    function increaseTime(uint256 t) public {
+        time += t;
+    }
+
+    function _now() internal view returns (uint256) {
+        return time;
+    }
+
+
+}


### PR DESCRIPTION


-Added a function returning now to replace block.timestamp
-Added MockFantomLiquidationManager.sol inheriting FantomLiquidationManager.sol to mock time fast forward
-Added another test scenario whereby the borrower deposits two types of tokens as collateral